### PR TITLE
Do not assume getSelectedPage() returns IEditorPart

### DIFF
--- a/io.emmet.eclipse/src/io/emmet/eclipse/EclipseEmmetHelper.java
+++ b/io.emmet.eclipse/src/io/emmet/eclipse/EclipseEmmetHelper.java
@@ -49,7 +49,7 @@ public class EclipseEmmetHelper {
 	 * @return
 	 */
 	public static IEditorPart getTextEditor(IEditorPart editor) {
-		if (editor instanceof MultiPageEditorPart) {
+		if (editor instanceof MultiPageEditorPart && editor.getSelectedPage() instanceof IEditorPart) {
 			IEditorPart currentPage = (IEditorPart) ((MultiPageEditorPart) editor).getSelectedPage();
 
 			if (currentPage instanceof ITextEditor) {


### PR DESCRIPTION
Add check that selected page is actually an IEditorPart to avoid classcast exception.

I'm trying out emmet and noticed I hit this exception:

java.lang.ClassCastException: org.eclipse.swt.widgets.Composite cannot be cast to org.eclipse.ui.IEditorPart
    at io.emmet.eclipse.EclipseEmmetHelper.getTextEditor(EclipseEmmetHelper.java:53)
    at io.emmet.eclipse.TabKeyHandler.uninstall(TabKeyHandler.java:95)
    at io.emmet.eclipse.TabKeyHandler$2.partClosed(TabKeyHandler.java:216)
    at org.eclipse.ui.internal.WorkbenchPage$20.run(WorkbenchPage.java:4874)
    at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
    at org.eclipse.ui.internal.WorkbenchPage.firePartClosed(WorkbenchPage.java:4872)
    at org.eclipse.ui.internal.e4.compatibility.CompatibilityPart$1.handleEvent(CompatibilityPart.java:101)
<stripped out eclipse even stackframes>

This only happens when opening JBoss Tools Properties page editor which does not return IEditorPart for getPages(). I'm investigating why that is but I would say it would be good if emmet would not assume this.

Here is a simple fix for this issue.
