### PR TITLE
#27 change conflicting keybinding CTRL+D to new one CTRL+ALT+D

### DIFF
--- a/io.emmet.eclipse/plugin.xml
+++ b/io.emmet.eclipse/plugin.xml
@@ -137,7 +137,7 @@
       <key
             commandId="io.emmet.eclipse.commands.match_pair_outward"
             contextId="org.eclipse.ui.textEditorScope"
-            sequence="M1+D"
+            sequence="M3+CTRL+D"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
       </key>
       <key


### PR DESCRIPTION
CTRL+D is the keybinding for delete line in all eclipse text editors.
CTRL+ALT+D is not used as a text editor keybinding yet (in my eclipse install)  so would be a much better match for this.
